### PR TITLE
use |= rather than += for bufeq_secure

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -173,7 +173,7 @@
       } else {
         check = 0;
         for (i = _i = 0, _ref = x.length; 0 <= _ref ? _i < _ref : _i > _ref; i = 0 <= _ref ? ++_i : --_i) {
-          check += x.readUInt8(i) ^ y.readUInt8(i);
+          check |= x.readUInt8(i) ^ y.readUInt8(i);
         }
         return check === 0;
       }

--- a/src/util.iced
+++ b/src/util.iced
@@ -80,7 +80,7 @@ exports.bufeq_secure = bufeq_secure = (x,y) ->
   else
     check = 0
     for i in [0...x.length]
-      check += (x.readUInt8(i) ^ y.readUInt8(i))
+      check |= (x.readUInt8(i) ^ y.readUInt8(i))
     (check is 0)
   return ret
 


### PR DESCRIPTION
I know it's an extremely remote possibility, but I chose to use `|=` rather than `+=` when writing [`buffer-equal-constant-time`](https://github.com/goinstant/buffer-equal-constant-time/blob/master/index.js#L8).  It has the added benefit of keeping within a `uint32_t` and can therefore be optimized into integer rather than floating point machine code instructions.

If you know a good reason to not use `|=`, please let me know!
